### PR TITLE
Renewed scorecard

### DIFF
--- a/app/helpers/scorecards_helper.rb
+++ b/app/helpers/scorecards_helper.rb
@@ -36,9 +36,8 @@ module ScorecardsHelper
   end
 
   def status_html(scorecard)
-    css_klass = scorecard.completed? ? "badge-success" : "badge-warning"
-    progress = scorecard.progress.blank? ? "" : " (#{I18n.t('scorecard.' + scorecard.progress)})"
-    "<span class='badge #{css_klass}'>#{scorecard.status}#{progress}</span>"
+    status_type = ['status', scorecard.status, scorecard.progress, 'html'].compact.join('_')
+    send(status_type, scorecard.status) rescue scorecard.status
   end
 
   def filter_date_options

--- a/app/helpers/scorecards_statuses_helper.rb
+++ b/app/helpers/scorecards_statuses_helper.rb
@@ -1,0 +1,25 @@
+module ScorecardsStatusesHelper
+  def status_planned_renewed_html(status)
+    content_tag :span, class: "badge badge-danger" do
+      "#{status} (#{t('scorecard.renewed')})"
+    end
+  end
+
+  def status_planned_html(status)
+    content_tag :span, class: "badge badge-warning" do
+      status
+    end
+  end
+
+  def status_planned_running_html(status)
+    content_tag :span, class: "badge badge-warning" do
+      "#{status} (#{t('scorecard.running')})"
+    end
+  end
+
+  def status_completed_submitted_html(status)
+    content_tag :span, class: "badge badge-success" do
+      "#{status} (#{t('scorecard.submitted')})"
+    end
+  end
+end

--- a/app/helpers/scorecards_statuses_helper.rb
+++ b/app/helpers/scorecards_statuses_helper.rb
@@ -6,9 +6,7 @@ module ScorecardsStatusesHelper
   end
 
   def status_planned_html(status)
-    content_tag :span, class: "badge badge-warning" do
-      status
-    end
+    content_tag :span, status, class: "badge badge-warning"
   end
 
   def status_planned_running_html(status)

--- a/app/helpers/scorecards_statuses_helper.rb
+++ b/app/helpers/scorecards_statuses_helper.rb
@@ -22,4 +22,10 @@ module ScorecardsStatusesHelper
       "#{status} (#{t('scorecard.submitted')})"
     end
   end
+
+  def status_planned_downloaded_html(status)
+    content_tag :span, class: "badge badge-warning" do
+      "#{status} (#{t('scorecard.downloaded')})"
+    end
+  end
 end

--- a/app/models/scorecard.rb
+++ b/app/models/scorecard.rb
@@ -117,6 +117,10 @@ class Scorecard < ApplicationRecord
     access_locked?
   end
 
+  def renewed?
+    progress == 'renewed'
+  end
+
   private
     def secure_uuid
       self.uuid ||= six_digit_rand

--- a/app/models/scorecard_progress.rb
+++ b/app/models/scorecard_progress.rb
@@ -17,7 +17,8 @@ class ScorecardProgress < ApplicationRecord
   enum status: {
     downloaded: 1,
     running: 2,
-    submitted: 3
+    submitted: 3,
+    renewed: 4
   }
 
   after_save :set_scorecard_progress

--- a/app/models/scorecard_progress.rb
+++ b/app/models/scorecard_progress.rb
@@ -33,7 +33,7 @@ class ScorecardProgress < ApplicationRecord
     end
 
     def set_scorecard_progress
-      return if self.class.statuses[scorecard.progress].to_i >= self.class.statuses[status]
+      return if !scorecard.renewed? && self.class.statuses[scorecard.progress].to_i >= self.class.statuses[status].to_i
 
       scorecard.progress = status
       scorecard.save(validate: false)

--- a/app/views/scorecards/index.html.haml
+++ b/app/views/scorecards/index.html.haml
@@ -48,7 +48,7 @@
                 %td= scorecard.facility.name
                 %td= scorecard.local_ngo.name
                 %td= scorecard_location(scorecard)
-                %th= status_html(scorecard).html_safe
+                %td= status_html(scorecard)
                 %td= timeago(scorecard.created_at).html_safe
                 %td
                   - if scorecard.locked_at.present?

--- a/config/locales/scorecard/en.yml
+++ b/config/locales/scorecard/en.yml
@@ -80,6 +80,7 @@ en:
     downloaded: downloaded
     running: running
     submitted: submitted
+    renewed: renewed
     references: References
     implemented_date: Implemented date
     submitted_date: Submitted date

--- a/config/locales/scorecard/km.yml
+++ b/config/locales/scorecard/km.yml
@@ -80,6 +80,7 @@ km:
     downloaded: ទាញយករួច
     running: កំពុងដំណើរការ
     submitted: បានដាក់ស្នើ
+    renewed: ស្នើឡើងវិញ
     references: ឯកសារយោង
     implemented_date: កាលបរិច្ឆេទអនុវត្ត
     submitted_date: កាលបរិច្ឆេទទទួលបានសំណើរ

--- a/spec/factories/scorecards.rb
+++ b/spec/factories/scorecards.rb
@@ -49,6 +49,7 @@ FactoryBot.define do
     program
     creator
     local_ngo
+    status       { 'planned' }
     scorecard_type { Scorecard::SCORECARD_TYPES.sample.last }
     commune_id   { Pumi::Commune.all.sample.id }
     district_id  { Pumi::Commune.find_by_id(commune_id).try(:district_id) }

--- a/spec/helpers/scorecards_helper_spec.rb
+++ b/spec/helpers/scorecards_helper_spec.rb
@@ -2,16 +2,32 @@
 
 require "rails_helper"
 
-# Specs in this file have access to a helper object that includes
-# the ScorecardsHelper. For example:
-#
-# describe ScorecardsHelper do
-#   describe "string concat" do
-#     it "concats two strings with spaces" do
-#       expect(helper.concat_strings("this","that")).to eq("this that")
-#     end
-#   end
-# end
 RSpec.describe ScorecardsHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "#status_html" do
+    let(:planned_scorecard) { build(:scorecard) }
+    let(:completed_scorecard) { build(:scorecard, progress: 'submitted') }
+
+    it "#status_planned_html" do
+      expect(helper).to receive(:status_planned_html).with('planned')
+      helper.status_html(planned_scorecard)
+    end
+
+    it "#status_planned_renewed_html" do
+      planned_scorecard.progress = 'renewed'
+      expect(helper).to receive(:status_planned_renewed_html).with('planned')
+      helper.status_html(planned_scorecard)
+    end
+
+    it "#status_planned_running_html" do
+      planned_scorecard.progress = 'running'
+      expect(helper).to receive(:status_planned_running_html).with('planned')
+      helper.status_html(planned_scorecard)
+    end
+
+    it "#status_completed_submitted_html" do
+      completed_scorecard.locked_at = DateTime.current
+      expect(helper).to receive(:status_completed_submitted_html).with('completed')
+      helper.status_html(completed_scorecard)
+    end
+  end
 end

--- a/spec/models/scorecard_progress_spec.rb
+++ b/spec/models/scorecard_progress_spec.rb
@@ -15,7 +15,7 @@ require "rails_helper"
 
 RSpec.describe ScorecardProgress, type: :model do
   it { is_expected.to belong_to(:scorecard).with_foreign_key(:scorecard_uuid) }
-  it { is_expected.to define_enum_for(:status).with_values({ downloaded: 1, running: 2, submitted: 3 }) }
+  it { is_expected.to define_enum_for(:status).with_values({ downloaded: 1, running: 2, submitted: 3, renewed: 4 }) }
 
   describe "#after_save: set_scorecard_progress" do
     context "scorecard progress is smaller than scorecard_progress status" do

--- a/spec/models/scorecard_progress_spec.rb
+++ b/spec/models/scorecard_progress_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe ScorecardProgress, type: :model do
       end
     end
 
+    context "#renewed" do
+      let!(:scorecard) { create(:scorecard, progress: :running) }
+      let!(:scorecard_progress) { create(:scorecard_progress, status: :renewed, scorecard: scorecard) }
+
+      it "set scorecard progress to downloaded" do
+        expect(scorecard.reload.progress).to eq("renewed")
+      end
+    end
+
     context "scorecard is locked" do
       let!(:scorecard) { create(:scorecard, progress: :running) }
       let(:scorecard_progress) { build(:scorecard_progress, status: :submitted, scorecard: scorecard) }

--- a/spec/models/scorecard_progress_spec.rb
+++ b/spec/models/scorecard_progress_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ScorecardProgress, type: :model do
       let!(:scorecard) { create(:scorecard, progress: :running) }
       let!(:scorecard_progress) { create(:scorecard_progress, status: :renewed, scorecard: scorecard) }
 
-      it "set scorecard progress to downloaded" do
+      it "sets scorecard progress to renewed" do
         expect(scorecard.reload.progress).to eq("renewed")
       end
     end


### PR DESCRIPTION
### Issue

Deleted scorecard cannot re-download once it is deleted.
[Detail on Jira](https://ilabsea.atlassian.net/secure/RapidBoard.jspa?rapidView=10&projectKey=CSCWEB&modal=detail&selectedIssue=CSCWEB-125)

### Change request
Introduces a new status in scorecard progress model call `renewed`.
![image](https://user-images.githubusercontent.com/5484758/132201333-23169916-bfaf-457d-8488-df8df436af0f.png)


1. Mobile user will trigger a callback when scorecard is deleted by sending a POST request to create a new scorecard progress with status `renewed`
2. Renewed scorecard can re-download and restart the progress just like a brand-new scorecard

