### PR TITLE
Fix: update deprecated method update_attributes to update

### DIFF
--- a/app/controllers/local_ngos/cafs_controller.rb
+++ b/app/controllers/local_ngos/cafs_controller.rb
@@ -37,7 +37,7 @@ module LocalNgos
     def update
       @caf = authorize Caf.find(params[:id])
 
-      if @caf.update_attributes(caf_params)
+      if @caf.update(caf_params)
         redirect_to local_ngo_cafs_url(@local_ngo)
       else
         render :edit

--- a/app/controllers/local_ngos_controller.rb
+++ b/app/controllers/local_ngos_controller.rb
@@ -34,7 +34,7 @@ class LocalNgosController < ApplicationController
   def update
     @local_ngo = authorize LocalNgo.find(params[:id])
 
-    if @local_ngo.update_attributes(local_ngo_params)
+    if @local_ngo.update(local_ngo_params)
       redirect_to local_ngos_url
     else
       render :edit

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -32,7 +32,7 @@ class MessagesController < ApplicationController
   def update
     @message = current_program.messages.find(params[:id])
 
-    if @message.update_attributes(message_params)
+    if @message.update(message_params)
       redirect_to messages_url
     else
       render :edit

--- a/app/controllers/pdf_templates_controller.rb
+++ b/app/controllers/pdf_templates_controller.rb
@@ -41,7 +41,7 @@ class PdfTemplatesController < ApplicationController
   def update
     @pdf_template = authorize PdfTemplate.find(params[:id])
 
-    if @pdf_template.update_attributes(pdf_template_params)
+    if @pdf_template.update(pdf_template_params)
       redirect_to pdf_templates_url
     else
       render :edit

--- a/app/controllers/primary_schools_controller.rb
+++ b/app/controllers/primary_schools_controller.rb
@@ -34,7 +34,7 @@ class PrimarySchoolsController < ApplicationController
   def update
     @primary_school = authorize PrimarySchool.find(params[:id])
 
-    if @primary_school.update_attributes(primary_school_params)
+    if @primary_school.update(primary_school_params)
       redirect_to primary_schools_url
     else
       render :edit

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -34,7 +34,7 @@ class ProgramsController < ApplicationController
   def update
     @program = authorize Program.find(params[:id])
 
-    if @program.update_attributes(program_params)
+    if @program.update(program_params)
       redirect_to programs_url
     else
       render :edit

--- a/app/controllers/scorecards_controller.rb
+++ b/app/controllers/scorecards_controller.rb
@@ -46,7 +46,7 @@ class ScorecardsController < ApplicationController
   def update
     authorize @scorecard
 
-    if @scorecard.update_attributes(scorecard_params)
+    if @scorecard.update(scorecard_params)
       redirect_to scorecards_url
     else
       render :edit

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -34,7 +34,7 @@ class TemplatesController < ApplicationController
   def update
     @template = authorize ::Template.find(params[:id])
 
-    if @template.update_attributes(template_params)
+    if @template.update(template_params)
       redirect_to templates_url
     else
       render :edit

--- a/app/models/notifications/telegram.rb
+++ b/app/models/notifications/telegram.rb
@@ -24,7 +24,7 @@ module Notifications
       chat_groups.actives.each do |group|
         bot.send_message(chat_id: group.chat_id, text: display_message, parse_mode: :HTML)
       rescue ::Telegram::Bot::Forbidden => e
-        group.update_attributes(actived: false, reason: e)
+        group.update(actived: false, reason: e)
       end
     end
 


### PR DESCRIPTION
- Fixed by using update method instead as the update_attributes method is deprecated in Rails 6.1