### PR TITLE
add new column device_type to scorecard progress

### DIFF
--- a/app/controllers/api/v1/scorecard_progresses_controller.rb
+++ b/app/controllers/api/v1/scorecard_progresses_controller.rb
@@ -16,7 +16,7 @@ module Api
       private
         def scorecard_progress_params
           params.require(:scorecard_progress).permit(
-            :scorecard_uuid, :status, :device_id
+            :scorecard_uuid, :status, :device_id, :device_type
           ).merge(user_id: current_user.id)
         end
     end

--- a/app/models/scorecard_progress.rb
+++ b/app/models/scorecard_progress.rb
@@ -11,6 +11,7 @@
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  user_id        :integer
+#  device_type    :string
 #
 class ScorecardProgress < ApplicationRecord
   belongs_to :scorecard, primary_key: "uuid", foreign_key: "scorecard_uuid"

--- a/db/migrate/20211203030248_add_device_type_to_scorecard_progresses.rb
+++ b/db/migrate/20211203030248_add_device_type_to_scorecard_progresses.rb
@@ -1,0 +1,5 @@
+class AddDeviceTypeToScorecardProgresses < ActiveRecord::Migration[6.1]
+  def change
+    add_column :scorecard_progresses, :device_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_29_102332) do
+ActiveRecord::Schema.define(version: 2021_12_03_030248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -400,6 +400,7 @@ ActiveRecord::Schema.define(version: 2021_11_29_102332) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "user_id"
+    t.string "device_type"
   end
 
   create_table "scorecard_references", force: :cascade do |t|

--- a/spec/factories/scorecard_progresses.rb
+++ b/spec/factories/scorecard_progresses.rb
@@ -11,6 +11,7 @@
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  user_id        :integer
+#  device_type    :string
 #
 FactoryBot.define do
   factory :scorecard_progress do

--- a/spec/models/scorecard_progress_spec.rb
+++ b/spec/models/scorecard_progress_spec.rb
@@ -11,6 +11,7 @@
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  user_id        :integer
+#  device_type    :string
 #
 require "rails_helper"
 


### PR DESCRIPTION
This pull request is adding a new column device_type to scorecard progress to record the device type (mobile or tablet) when the user updates the progress of the scorecard.