### PR TITLE
Indicator: add rake task to migrate missing indicator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN bundle exec rake assets:precompile RAILS_ENV=production
 
 ENV RAILS_LOG_TO_STDOUT=true
 ENV RACK_ENV=production
-ENV RAILS_ENV=staging
+ENV RAILS_ENV=production
 EXPOSE 80
 
 COPY docker/database.yml /app/config/database.yml

--- a/app/models/custom_indicator.rb
+++ b/app/models/custom_indicator.rb
@@ -19,7 +19,7 @@ class CustomIndicator < ApplicationRecord
 
   mount_uploader :audio, AudioUploader
 
-  belongs_to :scorecard, foreign_key: :scorecard_uuid
+  belongs_to :scorecard, -> { with_deleted }, foreign_key: :scorecard_uuid
 
   validates :name, presence: true
 

--- a/lib/tasks/indicator.rake
+++ b/lib/tasks/indicator.rake
@@ -23,4 +23,18 @@ namespace :indicator do
       )
     end
   end
+
+  desc "migrate missing custom_indicator"
+  task migrate_missing_custom_indicator: :environment do
+    miss_custom_indicators = CustomIndicator.where.not(uuid: Indicators::CustomIndicator.pluck(:uuid))
+    miss_custom_indicators.each do |ci|
+      indi = ci.scorecard.facility.indicators.find_or_initialize_by(uuid: ci.uuid)
+      indi.update(
+        name: ci.name,
+        tag_id: ci.tag_id,
+        audio: ci.audio,
+        type: "Indicators::CustomIndicator"
+      )
+    end
+  end
 end


### PR DESCRIPTION
When deploying, please run
1) bundle exec rake indicator:migrate_missing_custom_indicator
2) bundle exec rake raised_indicator:migrate_missing_raised_and_voting_indicator
