### PR TITLE
Scorecard: allow only file .xlsx to be imported

### DIFF
--- a/app/models/spreadsheets/base_spreadsheet.rb
+++ b/app/models/spreadsheets/base_spreadsheet.rb
@@ -24,7 +24,7 @@ class Spreadsheets::BaseSpreadsheet
     end
 
     def accepted_formats
-      [".xls", ".xlsx"]
+      [".xlsx"]
     end
 
     def parse_string(data)

--- a/app/views/shared/forms/_wizard_form.html.haml
+++ b/app/views/shared/forms/_wizard_form.html.haml
@@ -27,7 +27,7 @@
           .card-body
             %span.mr-2 2.
             .form-control.file-control-wrapper
-              = f.file_field :file, accept: ".xls,.xlsx"
+              = f.file_field :file, accept: ".xlsx"
 
         %small= t('scorecard_batch.excel_file')
 


### PR DESCRIPTION
Reason: gem [caxlsx_rails:0.6.3](https://github.com/caxlsx/caxlsx_rails/tree/v0.6.3) support only file with extension .xlsx