### PR TITLE
Close #467 fix api to create grafana dashboard and user

### DIFF
--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -36,7 +36,7 @@ class Dashboard
   end
 
   def create_org
-    option = { basic_auth: auth, body: { name: program.name } }
+    option = { basic_auth: auth, body: { name: program.name }.to_json, headers: { "Content-Type" => "application/json" } }
 
     result = self.class.post("/api/orgs", option)
     gf_dashboard.update(org_id: result.parsed_response["orgId"]) if result.response.is_a?(Net::HTTPSuccess)
@@ -49,7 +49,7 @@ class Dashboard
   end
 
   def create_org_token
-    option = { basic_auth: auth, body: { name: "#{program.name}_apikey", role: "Admin" } }
+    option = { basic_auth: auth, body: { name: "#{program.name}_apikey", role: "Admin" }.to_json, headers: { "Content-Type" => "application/json" } }
 
     result = self.class.post("/api/auth/keys", option)
     gf_dashboard.update(org_token: result.parsed_response["key"]) if result.response.is_a?(Net::HTTPSuccess)
@@ -84,8 +84,9 @@ class Dashboard
         email: user.email,
         login: user.email,
         password: SecureRandom.uuid,
-        org_id: gf_dashboard.org_id
-      }
+        orgId: gf_dashboard.org_id
+      }.to_json,
+      headers: { "Content-Type" => "application/json" }
     }
 
     result = self.class.post("/api/admin/users", option)


### PR DESCRIPTION
## Pull request overview

This PR fixes critical issues with Grafana API integration that were preventing dashboard and user creation (issue #467). The changes update API request formatting to match Grafana's requirements and upgrade the dashboard configuration from Grafana version 8.3.3 to 10.1.4.

**Key changes:**
- Fixed Grafana API calls by adding JSON serialization (`.to_json`) and `Content-Type: application/json` headers to POST requests
- Changed API parameter from `org_id` to `orgId` to match Grafana's expected format
- Upgraded dashboard configuration for Grafana 10.1.4 with improved SQL queries using COALESCE/NULLIF for division-by-zero protection