### PR TITLE
Close #469 remove close button in test mode message

### DIFF
--- a/app/views/shared/_test_mode_message.haml
+++ b/app/views/shared/_test_mode_message.haml
@@ -1,7 +1,4 @@
 - if test_mode?
-  .alert.alert-danger.test-mode-message.alert-dismissible.fade.show
+  .alert.alert-danger.test-mode-message.fade.show
     %i.fas.fa-info-circle
     %span= t('shared.you_are_in_testing_mode')
-
-    %button.close{ type: "button", "data-dismiss": "alert", "aria-label": "Close" }
-      %span{"aria-hidden": "true"} &times;


### PR DESCRIPTION
## What does this PR do?
- Remove the close button of the test mode message.


## Screenshot
<img width="1506" height="388" alt="Screenshot 2025-12-04 at 2 14 40 PM" src="https://github.com/user-attachments/assets/54e86ad4-fe44-42c3-8c6c-1b4155adbf91" />
