### PR TITLE
Close #473 update sample data to remove subfix language code

### DIFF
--- a/lib/samples/indicator.rb
+++ b/lib/samples/indicator.rb
@@ -41,7 +41,7 @@ module Samples
           lang_indi.update(
             language_id: language.id,
             language_code: language.code,
-            content: "#{indicator.name} (#{language.code})",
+            content: indicator.name,
             audio: Pathname.new(audio).open
           )
         end

--- a/lib/samples/rating_scale.rb
+++ b/lib/samples/rating_scale.rb
@@ -42,7 +42,7 @@ module Samples
           lang_rating_scale.update(
             language_id: language.id,
             language_code: language.code,
-            content: "#{rating_scale.name} (#{language.code})",
+            content: rating_scale.name,
             audio: Pathname.new(audio).open
           )
         end


### PR DESCRIPTION
**What does this PR do?**

* Updates the sample data to remove the language code suffix.
* After this change, you can run the following in the Rails console to migrate program data caused by the language code suffix:

```ruby
target_program = Program.find_by(name: 'Plastic Smart')

require "samples/sample"
::Samples::Indicator.load(target_program.name)       # Load indicators under facilities
::Samples::RatingScale.load(target_program.name)     # Load rating scales (Bad, Very Bad, Acceptable, Good, Very Good) 
                                                     # with audio files and 6 locales from the languages above
```

---

**Screenshot**
<img width="1374" height="761" alt="Screenshot 2025-12-04 at 4 14 56 PM" src="https://github.com/user-attachments/assets/a5e47e5b-12bd-4ee5-9cf0-fe3a99180fee" />
<img width="1433" height="602" alt="Screenshot 2025-12-04 at 4 15 06 PM" src="https://github.com/user-attachments/assets/5a4c16a1-615b-41fb-9a17-6512d3f30989" />
