### PR TITLE
Close #475 fix email to proposer when reject request change

### DIFF
--- a/app/models/concerns/request_changes/callback_notification.rb
+++ b/app/models/concerns/request_changes/callback_notification.rb
@@ -14,8 +14,8 @@ module RequestChanges::CallbackNotification
       send_mail(scorecard.creator.email, display_message)
     end
 
-    def notify_status_rejected_to_proposer_async
-      display_message = "Your request change on the scorecard #{scorecard.uuid} has been rejeted. Reason: #{rejected_reason}"
+    def notify_status_rejected_to_proposer
+      display_message = "Your request change on the scorecard #{scorecard.uuid} has been rejected. Reason: #{rejected_reason}"
 
       send_mail(proposer.email, display_message)
     end

--- a/spec/models/request_changes/callback_notification_spec.rb
+++ b/spec/models/request_changes/callback_notification_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe RequestChanges::CallbackNotification do
         expect {
           request_change.update(status: :approved, reviewer: reviewer)
         }.to change(RequestChangeWorker.jobs, :size).by(1)
+        args = RequestChangeWorker.jobs.last['args']
+        expect(args).to eq(['notify_status_approved_to_proposer', request_change.id])
       }
     end
 
@@ -24,7 +26,26 @@ RSpec.describe RequestChanges::CallbackNotification do
         expect {
           request_change.update(status: :rejected, reviewer: reviewer, rejected_reason: "I reject it")
         }.to change(RequestChangeWorker.jobs, :size).by(1)
+        args = RequestChangeWorker.jobs.last['args']
+        expect(args).to eq(['notify_status_rejected_to_proposer', request_change.id])
       }
+    end
+  end
+
+  describe "#notify_status_rejected_to_proposer" do
+    let(:reviewer) { create(:user) }
+    let(:request_change) { create(:request_change, rejected_reason: 'Bad request', status: :rejected, reviewer: reviewer ) }
+
+    it "sends an email via NotificationMailer with expected payload" do
+      mail = double('mail')
+      expect(mail).to receive(:deliver_now)
+
+      expect(NotificationMailer).to receive(:notify_request_change).with(
+        request_change.proposer.email,
+        hash_including(:scorecard, :request_change, :body_message)
+      ).and_return(mail)
+
+      request_change.notify_status_rejected_to_proposer
     end
   end
 end

--- a/spec/workers/request_change_worker_spec.rb
+++ b/spec/workers/request_change_worker_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RequestChangeWorker do
+  describe "#perform" do
+    let!(:request_change) { create(:request_change) }
+
+    it "invokes the target method on the RequestChange instance" do
+      expect_any_instance_of(RequestChange).to receive(:notify_status_rejected_to_proposer)
+
+      described_class.new.perform('notify_status_rejected_to_proposer', request_change.id)
+    end
+
+    it "logs and returns gracefully when record not found" do
+      allow(Rails.logger).to receive(:error)
+
+      expect {
+        described_class.new.perform('notify_status_rejected_to_proposer', 0)
+      }.not_to raise_error
+
+      expect(Rails.logger).to have_received(:error)
+    end
+  end
+end


### PR DESCRIPTION
## Pull request overview

This PR fixes a bug where email notifications to proposers were failing when request changes were rejected. The issue was a naming mismatch: the public method was named `notify_status_rejected_to_proposer_async`, but the worker attempted to call `notify_status_rejected_to_proposer`, causing the notification to fail silently. The fix renames the public method to match what the worker expects, following the established pattern where async wrappers (with `_async` suffix) enqueue jobs that invoke public methods (without the suffix).

- Renamed the public notification method from `notify_status_rejected_to_proposer_async` to `notify_status_rejected_to_proposer`
- Added comprehensive test coverage for the worker behavior
- Added a dedicated test for the renamed notification method