### PR TITLE
Close #494 allow only lngo user to download and submit scorecard

### DIFF
--- a/app/policies/scorecard_policy.rb
+++ b/app/policies/scorecard_policy.rb
@@ -13,7 +13,7 @@ class ScorecardPolicy < ApplicationPolicy
   end
 
   def download?
-    (user.program_id == record.program_id) && (create? || user.local_ngo_id == record.local_ngo_id)
+    user.local_ngo_id.present? && user.local_ngo_id == record.local_ngo_id
   end
 
   def download_pdf?

--- a/spec/policies/scorecard_policy_spec.rb
+++ b/spec/policies/scorecard_policy_spec.rb
@@ -109,8 +109,8 @@ RSpec.describe ScorecardPolicy do
       let(:scorecard) { create(:scorecard) }
       let(:user) { User.new(role: :staff, program_id: scorecard.program_id) }
 
-      it "accept access" do
-        expect(subject).to permit(user, scorecard)
+      it "denies access" do
+        expect(subject).not_to permit(user, scorecard)
       end
     end
 
@@ -118,8 +118,8 @@ RSpec.describe ScorecardPolicy do
       let(:scorecard) { create(:scorecard) }
       let(:user) { User.new(role: :program_admin, program_id: scorecard.program_id) }
 
-      it "accept access" do
-        expect(subject).to permit(user, scorecard)
+      it "denies access" do
+        expect(subject).not_to permit(user, scorecard)
       end
     end
   end
@@ -169,8 +169,8 @@ RSpec.describe ScorecardPolicy do
       let(:scorecard) { create(:scorecard) }
       let(:user) { User.new(role: :staff, program_id: scorecard.program_id) }
 
-      it "accept access" do
-        expect(subject).to permit(user, scorecard)
+      it "denies access" do
+        expect(subject).not_to permit(user, scorecard)
       end
     end
 
@@ -178,8 +178,8 @@ RSpec.describe ScorecardPolicy do
       let(:scorecard) { create(:scorecard) }
       let(:user) { User.new(role: :program_admin, program_id: scorecard.program_id) }
 
-      it "accept access" do
-        expect(subject).to permit(user, scorecard)
+      it "denies access" do
+        expect(subject).not_to permit(user, scorecard)
       end
     end
   end

--- a/spec/requests/api/v1/custom_indicators_request_spec.rb
+++ b/spec/requests/api/v1/custom_indicators_request_spec.rb
@@ -4,8 +4,8 @@ require "rails_helper"
 
 RSpec.describe "Api::V1::CustomIndicatorsController", type: :request do
   describe "POST #create" do
-    let!(:user)       { create(:user) }
-    let!(:scorecard)  { create(:scorecard, program_id: user.program_id) }
+    let!(:user)       { create(:user, :lngo) }
+    let!(:scorecard)  { create(:scorecard, program_id: user.program_id, local_ngo_id: user.local_ngo_id) }
     let(:json_response) { JSON.parse(response.body) }
     let(:headers)     { { "ACCEPT" => "application/json", "Authorization" => "Token #{user.authentication_token}" } }
     let(:params)      { { name: "Staff not commig on time", tag_attributes: { name: "timing" }, audio: "" } }

--- a/spec/requests/api/v1/scorecard_references_request_spec.rb
+++ b/spec/requests/api/v1/scorecard_references_request_spec.rb
@@ -4,8 +4,8 @@ require "rails_helper"
 
 RSpec.describe "Api::V1::ScorecardReferencesController", type: :request do
   describe "POST #create" do
-    let!(:user)       { create(:user) }
-    let!(:scorecard)  { create(:scorecard, program: user.program) }
+    let!(:user)       { create(:user, :lngo) }
+    let!(:scorecard)  { create(:scorecard, program: user.program, local_ngo_id: user.local_ngo_id) }
     let(:json_response) { JSON.parse(response.body) }
     let(:headers)     { { "ACCEPT" => "application/json", "Authorization" => "Token #{user.authentication_token}" } }
     let(:params)      { { uuid: "123", kind: "swot_result" } }

--- a/spec/requests/api/v1/scorecards_request_spec.rb
+++ b/spec/requests/api/v1/scorecards_request_spec.rb
@@ -5,8 +5,8 @@ require "stringio"
 
 RSpec.describe "Api::V1::ScorecardsController", type: :request do
   describe "GET #show" do
-    let!(:user) { create(:user) }
-    let!(:scorecard)  { create(:scorecard, program_id: user.program_id) }
+    let!(:user) { create(:user, :lngo) }
+    let!(:scorecard)  { create(:scorecard, program_id: user.program_id, local_ngo_id: user.local_ngo_id) }
     let(:headers)     { { "ACCEPT" => "application/json", "Authorization" => "Token #{user.authentication_token}" } }
 
     before {
@@ -61,8 +61,8 @@ RSpec.describe "Api::V1::ScorecardsController", type: :request do
   end
 
   describe "PUT #update" do
-    let!(:user)       { create(:user) }
-    let!(:scorecard)  { create(:scorecard, number_of_participant: 3, program_id: user.program_id) }
+    let!(:user)       { create(:user, :lngo) }
+    let!(:scorecard)  { create(:scorecard, number_of_participant: 3, program_id: user.program_id, local_ngo_id: user.local_ngo_id) }
     let(:headers)     { { "ACCEPT" => "application/json", "Authorization" => "Token #{user.authentication_token}" } }
     let(:params)      { { number_of_caf: 3, number_of_participant: 15, number_of_female: 5, app_version: 15013 } }
 
@@ -110,10 +110,10 @@ RSpec.describe "Api::V1::ScorecardsController", type: :request do
   end
 
   describe "PUT #update, suggested_actions_attributes" do
-    let!(:user)       { create(:user) }
+    let!(:user)       { create(:user, :lngo) }
     let!(:facility)   { create(:facility, :with_parent, :with_indicators) }
     let!(:indicator)   { facility.indicators.first }
-    let!(:scorecard)  { create(:scorecard, number_of_participant: 3, program: user.program, facility: facility) }
+    let!(:scorecard)  { create(:scorecard, number_of_participant: 3, program: user.program, local_ngo_id: user.local_ngo_id, facility: facility) }
     let(:headers)     { { "ACCEPT" => "application/json", "Authorization" => "Token #{user.authentication_token}" } }
     let(:params)      { { voting_indicators_attributes: [ {
                           uuid: "123", indicatorable_id: indicator.id, indicatorable_type: indicator.class, scorecard_uuid: scorecard.uuid, display_order: 1,
@@ -140,8 +140,8 @@ RSpec.describe "Api::V1::ScorecardsController", type: :request do
   end
 
   describe "PUT #update, facilitators_attributes with soft delete caf" do
-    let!(:user)       { create(:user) }
-    let!(:local_ngo)  { create(:local_ngo, program: user.program) }
+    let!(:local_ngo)  { create(:local_ngo) }
+    let!(:user)       { create(:user, :lngo, local_ngo: local_ngo, program: local_ngo.program) }
     let!(:caf1)        { create(:caf, local_ngo: local_ngo) }
     let!(:caf2)        { create(:caf, local_ngo: local_ngo) }
     let!(:scorecard)  { create(:scorecard, number_of_participant: 3, program: user.program, local_ngo: local_ngo) }
@@ -214,12 +214,12 @@ RSpec.describe "Api::V1::ScorecardsController", type: :request do
   end
 
   describe "PUT #update, raised_indicator and voting_indicators" do
-    let!(:user)       { create(:user) }
+    let!(:user)       { create(:user, :lngo) }
     let!(:facility)   { create(:facility, :with_parent, :with_indicators) }
     let!(:custom_indicator) { create(:indicator, type: "Indicators::CustomIndicator", categorizable: facility) }
     let!(:custom_indicator2) { create(:indicator, type: "Indicators::CustomIndicator", categorizable: facility) }
     let!(:indicator)   { facility.indicators.first }
-    let!(:scorecard)  { create(:scorecard, number_of_participant: 3, program: user.program, facility: facility) }
+    let!(:scorecard)  { create(:scorecard, number_of_participant: 3, program: user.program, facility: facility, local_ngo_id: user.local_ngo_id) }
     let(:headers)     { { "ACCEPT" => "application/json", "Authorization" => "Token #{user.authentication_token}" } }
     let(:params)      { { raised_indicators_attributes: [
                             { indicatorable_id: indicator.id, indicatorable_type: "Indicator", scorecard_uuid: scorecard.uuid, voting_indicator_uuid: "123", selected: true },


### PR DESCRIPTION
## Pull request overview

This pull request implements access control changes to restrict scorecard download and submission to only LNGO (Local NGO) users, as indicated by issue #494. The core change simplifies the `download?` policy method to only check if the user's `local_ngo_id` matches the scorecard's `local_ngo_id`, removing the previous logic that also allowed program admins and staff users with matching `program_id` to access scorecards.

**Key changes:**
- Modified the `download?` policy to restrict access exclusively to LNGO users with matching `local_ngo_id`
- Updated all related test files to create LNGO users and associate scorecards with the users' local NGO IDs
- Changed policy test expectations to reflect that staff and program_admin users can no longer download or submit scorecards
