### PR TITLE
Close #498 add rake task to export village

### DIFF
--- a/lib/tasks/villages.rake
+++ b/lib/tasks/villages.rake
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# lib/tasks/villages.rake
+require "axlsx"
+
+namespace :villages do
+  desc "Export village data to tmp/villages.xlsx"
+  task export: :environment do
+    output = Rails.root.join("tmp", "villages.xlsx")
+
+    Axlsx::Package.new do |p|
+      p.workbook.add_worksheet(name: "Villages") do |sheet|
+        # Header row
+        sheet.add_row [
+          "location_id",
+          "code",
+          "name_en",
+          "name_km"
+        ]
+
+        # Fetch Pumi communes (Pumi::Commune) for village name "All" option
+        Pumi::Commune.all.each do |commune|
+          sheet.add_row [
+            commune.id,
+            "#{commune.id}00",
+            "All",
+            "ទាំងអស់"
+          ], types: [:string, :string, :string, :string]
+        end
+
+        # Fetch Pumi villages (Pumi::Village)
+        Pumi::Village.all.each do |village|
+          sheet.add_row [
+            village.commune_id,
+            village.id,
+            village.name_en,
+            village.name_km
+          ], types: [:string, :string, :string, :string]
+        end
+      end
+
+      p.serialize(output.to_s)
+    end
+
+    puts "✅ Exported villages to #{output}"
+  rescue
+    abort "❌ Failed to export villages"
+  end
+end


### PR DESCRIPTION
## Pull request overview

This PR adds a new rake task to export village data to an Excel file, addressing issue #498. The task generates a spreadsheet containing both commune-level "All" options and individual village records from the Pumi gem.

**Key Changes:**
- Creates a new rake task `villages:export` that exports Pumi commune and village data to `tmp/villages.xlsx`
- Exports commune records as "All" options with generated codes (commune_id + "00")
- Exports all individual villages with their commune_id, id, English and Khmer names

## Screenshot
<img width="919" height="561" alt="Screenshot 2025-12-10 at 1 28 17 PM" src="https://github.com/user-attachments/assets/4157dd5e-44bc-4917-b76a-45310780a5df" />
